### PR TITLE
[CB-6422] Use cordova/exec/proxy instead of platform dupes

### DIFF
--- a/src/firefoxos/compass.js
+++ b/src/firefoxos/compass.js
@@ -39,5 +39,5 @@ var Compass = {
 var firefoxos = require('cordova/platform');
 
 module.exports = Compass;
-require('cordova/firefoxos/commandProxy').add('Compass', Compass);
+require('cordova/exec/proxy').add('Compass', Compass);
 


### PR DESCRIPTION
https://issues.apache.org/jira/browse/CB-6422
[CB-6422] Use cordova/exec/proxy instead of platform dupes
