### PR TITLE
Fixed invalid orientation reports on iOS related to landscape mode

### DIFF
--- a/doc/de/index.md
+++ b/doc/de/index.md
@@ -178,8 +178,6 @@ Ein `CompassHeading` Objekt wird an die `CompassSuccess` Callback-Funktion zurü
 
 *   Die `trueHeading` -Eigenschaft nur für Ortungsdienste aktiviert über zurückgegeben`navigator.geolocation.watchLocation()`.
 
-*   Für iOS 4 Geräte oben Rubrik Faktoren in das Gerät aktuelle Ausrichtung und verweist nicht auf die absolute Position für Anwendungen, die diese Ausrichtung unterstützt.
-
 ## CompassError
 
 A `CompassError` Objekt wird zurückgegeben, um die `compassError` Callback-Funktion, wenn ein Fehler auftritt.

--- a/doc/es/index.md
+++ b/doc/es/index.md
@@ -178,8 +178,6 @@ A `CompassHeading` objeto es devuelto a la `compassSuccess` función de callback
 
 *   El `trueHeading` propiedad es devuelto sólo para servicios de localización habilitados mediante`navigator.geolocation.watchLocation()`.
 
-*   Para los dispositivos iOS 4 arriba, rumbo factores en la orientación actual del dispositivo y no hace referencia a su posición absoluta, para aplicaciones que apoya esa orientación.
-
 ## CompassError
 
 A `CompassError` objeto es devuelto a la `compassError` función de devolución de llamada cuando se produce un error.

--- a/doc/fr/index.md
+++ b/doc/fr/index.md
@@ -178,8 +178,6 @@ A `CompassHeading` objet est retourné à la `compassSuccess` fonction de rappel
 
 *   La `trueHeading` propriété est retournée uniquement pour les services de localisation activées via`navigator.geolocation.watchLocation()`.
 
-*   Pour les appareils iOS 4 et au-dessus, rubrique facteurs dans l'orientation actuelle de l'appareil et ne fait pas référence à sa position absolue, pour les applications prenant en charge cette orientation.
-
 ## CompassError
 
 A `CompassError` objet est retourné à la `compassError` fonction de rappel lorsqu'une erreur survient.

--- a/doc/index.md
+++ b/doc/index.md
@@ -183,8 +183,6 @@ A `CompassHeading` object is returned to the `compassSuccess` callback function.
 
 - The `trueHeading` property is only returned for location services enabled via `navigator.geolocation.watchLocation()`.
 
-- For iOS 4 devices and above, heading factors in the device's current orientation, and does not reference its absolute position, for apps that supports that orientation.
-
 ## CompassError
 
 A `CompassError` object is returned to the `compassError` callback function when an error occurs.

--- a/doc/it/index.md
+++ b/doc/it/index.md
@@ -178,8 +178,6 @@ A `CompassHeading` oggetto viene restituito alla `compassSuccess` funzione di ca
 
 *   La `trueHeading` proprietà viene restituito solo per servizi di localizzazione attivate tramite`navigator.geolocation.watchLocation()`.
 
-*   Per i dispositivi iOS 4 sopra, voce fattori nell'orientamento corrente del dispositivo e non fa riferimento la sua posizione assoluta, per le app che supporta tale orientamento.
-
 ## CompassError
 
 A `CompassError` oggetto viene restituito alla `compassError` funzione di callback quando si verifica un errore.

--- a/doc/pl/index.md
+++ b/doc/pl/index.md
@@ -178,8 +178,6 @@ A `CompassHeading` obiekt jest zwracany do `compassSuccess` funkcji wywołania z
 
 *   `trueHeading`Właściwość jest zwracana tylko dla lokalizacji usług włączone za pomocą`navigator.geolocation.watchLocation()`.
 
-*   Urządzeń iOS 4 i powyżej pozycji czynniki w orientacji bieżącego urządzenia, a nie odwołuje się do pozycji absolutnej, dla aplikacji, które obsługuje tej orientacji.
-
 ## CompassError
 
 A `CompassError` obiekt jest zwracany do `compassError` funkcji wywołania zwrotnego, gdy wystąpi błąd.

--- a/src/ios/CDVCompass.m
+++ b/src/ios/CDVCompass.m
@@ -200,11 +200,9 @@
     }
 }
 
-// helper method to check the orientation and start updating headings
+// helper method to start updating headings
 - (void)startHeadingWithFilter:(CLLocationDegrees)filter
 {
-    // FYI UIDeviceOrientation and CLDeviceOrientation enums are currently the same
-    self.locationManager.headingOrientation = (CLDeviceOrientation)self.viewController.interfaceOrientation;
     self.locationManager.headingFilter = filter;
     [self.locationManager startUpdatingHeading];
     self.headingData.headingStatus = HEADINGSTARTING;


### PR DESCRIPTION
The iOS plugin sets the locationManager.headingOrientation at the first heading request but later it doesn't adapt to (screen) orientation changes while the heading watch is running which causes invalid reports when the first request happens in landscape orientation.

The fix is just removing this setting.

### Note 1
The documentation is not clear about the plugin behaviour at screen orientation changes. The only place where it talks about this question is at iOS quirks: 

*"For iOS 4 devices and above, heading factors in the device's current orientation, and does not reference its absolute position, for apps that supports that orientation."*

This feature is not working correctly and being not compatible with other platforms it just creates unneeded hassle for the user. At the time both Android and iOS versions behave the same: nothing happens at orientation change. This is how the native sensor APIs are working too so I think that removing this is the correct fix of the problem.

I have removed this from the documentation too.

### Note 2
To correct the reported value based on screen orientation the user can do something like (Do not use the % operator because of this: http://wiki.ecmascript.org/doku.php?id=strawman:modulo_operator ):

var corrected = heading + window.orientation;
if (corrected < 0) {
   corrected += 360;
} else if (corrected >= 360) {
   corrected -= 360;
}

I haven't updated the documentation with this but I suggest to include this info