### PR TITLE
fix freezing Android Apps getCurrentHeading

### DIFF
--- a/src/android/CompassListener.java
+++ b/src/android/CompassListener.java
@@ -103,6 +103,11 @@ public class CompassListener extends CordovaPlugin implements SensorEventListene
             callbackContext.sendPluginResult(new PluginResult(PluginResult.Status.OK, i));
         }
         else if (action.equals("getHeading")) {
+            // if we didn't get a value for five seconds - stop so it will restart (fixes freezing on some devices)
+            if (this.status == CompassListener.RUNNING && System.currentTimeMillis() - this.timeStamp > 5_000)  {
+                this.stop();
+            }
+
             // If not running, then this is an async call, so don't worry about waiting
             if (this.status != CompassListener.RUNNING) {
                 int r = this.start();

--- a/src/android/CompassListener.java
+++ b/src/android/CompassListener.java
@@ -103,11 +103,6 @@ public class CompassListener extends CordovaPlugin implements SensorEventListene
             callbackContext.sendPluginResult(new PluginResult(PluginResult.Status.OK, i));
         }
         else if (action.equals("getHeading")) {
-            // if we didn't get a value for five seconds - stop so it will restart (fixes freezing on some devices)
-            if (this.status == CompassListener.RUNNING && System.currentTimeMillis() - this.timeStamp > 5_000)  {
-                this.stop();
-            }
-
             // If not running, then this is an async call, so don't worry about waiting
             if (this.status != CompassListener.RUNNING) {
                 int r = this.start();


### PR DESCRIPTION
### Platforms affected
Android ionic capacitor app


### Motivation and Context
https://github.com/apache/cordova-plugin-device-orientation/issues/81



### Description
Problem
When calling getCurrentHeading on some ionic apps on Android devices freeze out in the field.

What is expected to happen?
getCurrentHeading gets the heading at all times.

What does actually happen?
getCurrentHeading doesn't return a value any more. On some devices this is even causing a crash.



### Testing
tested change out in the field on many different Android devices


### Checklist

- [x ] I've run the tests to see all new and existing tests pass
- [x ] I added automated test coverage as appropriate for this change
- [x ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [x ] I've updated the documentation if necessary
